### PR TITLE
Layer export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+sample

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 sample
+.eslintrc.json

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "file-type": "3.3.0",
     "psd": "3.1.0",
     "read-chunk": "1.0.1",
-    "filenamify": "2.1.0"
+    "filenamify": "2.1.0",
+    "mkdirp": "0.5.1"
   },
   "devDependencies": {},
   "preferGlobal": true,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "commander": "2.9.0",
     "file-type": "3.3.0",
     "psd": "3.1.0",
-    "read-chunk": "1.0.1"
+    "read-chunk": "1.0.1",
+    "filenamify": "2.1.0"
   },
   "devDependencies": {},
   "preferGlobal": true,


### PR DESCRIPTION
Added `-l, --layers` option to export  all layers to PNGs.
Also added `-d, --dir <DIR>` option to specify output directory (for all options) because 50+ layers in source directory might be rather messy.